### PR TITLE
fix: update to use new labelle-tasks Context API

### DIFF
--- a/.labelle-bootstrap/build.zig.zon
+++ b/.labelle-bootstrap/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .@"labelle-engine" = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-engine?ref=v0.52.2",
+            .url = "git+https://github.com/labelle-toolkit/labelle-engine?ref=v0.52.5",
             .hash = "labelle_engine-0.52.5-rhO5vsd3GwDAwJrxOKXqBTo_98LGhJpgHjyRbr1pKD5m",
         },
     },

--- a/project.labelle
+++ b/project.labelle
@@ -2,7 +2,7 @@
     .version = 1,
     .name = "bakery-game",
     .description = "A bakery simulation demonstrating labelle-tasks plugin hooks",
-    .engine_version = "0.52.2",
+    .engine_version = "0.52.5",
     .initial_scene = "main",
     .backend = .raylib,
     .ecs_backend = .zig_ecs,

--- a/scenes/main.zon
+++ b/scenes/main.zon
@@ -1,6 +1,6 @@
 .{
     .name = "main",
-    .scripts = .{ "oven_builder", "task_initializer", "dangling_item_assigner", "storage_inspector", "worker_movement", "camera_control", "work_processor" },
+    .scripts = .{ "task_initializer", "dangling_item_assigner", "storage_inspector", "worker_movement", "camera_control", "work_processor" },
     .entities = .{
         // Baker (Worker) - will pick up dangling items
         .{
@@ -59,36 +59,8 @@
                 },
             },
         },
-        // EIS - Flour storage (external input from pantry)
-        .{
-            .components = .{
-                .Position = .{ .x = 100, .y = 300 },
-                .Shape = .{
-                    .shape = .{ .rectangle = .{ .width = 40, .height = 40 } },
-                    .color = .{ .r = 100, .g = 150, .b = 100, .a = 255 },
-                },
-                .Storage = .{
-                    .role = .eis,
-                    .accepts = .Flour,
-                },
-            },
-        },
-        // EIS - Water storage (external input from pantry)
-        .{
-            .components = .{
-                .Position = .{ .x = 100, .y = 360 },
-                .Shape = .{
-                    .shape = .{ .rectangle = .{ .width = 40, .height = 40 } },
-                    .color = .{ .r = 100, .g = 100, .b = 180, .a = 255 },
-                },
-                .Storage = .{
-                    .role = .eis,
-                    .accepts = .Water,
-                },
-            },
-        },
-        // Oven Workstation (commented out due to nested entity issue)
-        // .{ .prefab = "oven" },
+        // Oven Workstation (includes all storages: 2 EIS, 2 IIS, 1 IOS, 1 EOS)
+        .{ .prefab = "oven" },
         // Water Well (commented out due to nested entity issue)
         // .{ .prefab = "water_well" },
         // IOS - Bread storage (internal output for oven - commented out)

--- a/scripts/oven_builder.zig
+++ b/scripts/oven_builder.zig
@@ -64,10 +64,8 @@ pub fn init(game: *Game, scene: *Scene) void {
             const id = engine.entityToU64(entity);
             if (storage.accepts == .Flour) {
                 flour_eis_id = id;
-                Context.registerStorage(id, Items.Flour);
             } else if (storage.accepts == .Water) {
                 water_eis_id = id;
-                Context.registerStorage(id, Items.Water);
             }
         }
     }
@@ -84,7 +82,6 @@ pub fn init(game: *Game, scene: *Scene) void {
         .role = .iis,
         .accepts = Items.Flour,
     });
-    Context.registerStorage(flour_iis_id, Items.Flour);
 
     // Create IIS - Internal Water slot (recipe input)
     const water_iis_entity = registry.create();
@@ -98,7 +95,6 @@ pub fn init(game: *Game, scene: *Scene) void {
         .role = .iis,
         .accepts = Items.Water,
     });
-    Context.registerStorage(water_iis_id, Items.Water);
 
     // Create IOS - Internal Output slot (produced Bread)
     const bread_ios_entity = registry.create();
@@ -112,7 +108,6 @@ pub fn init(game: *Game, scene: *Scene) void {
         .role = .ios,
         .accepts = Items.Bread,
     });
-    Context.registerStorage(bread_ios_id, Items.Bread);
 
     // Create EOS - External Output storage (final Bread storage)
     const bread_eos_entity = registry.create();
@@ -126,7 +121,6 @@ pub fn init(game: *Game, scene: *Scene) void {
         .role = .eos,
         .accepts = Items.Bread,
     });
-    Context.registerStorage(bread_eos_id, Items.Bread);
 
     // Create array of storage IDs
     const storage_ids = [_]u64{

--- a/scripts/task_initializer.zig
+++ b/scripts/task_initializer.zig
@@ -36,8 +36,7 @@ pub fn init(game: *Game, scene: *Scene) void {
     var worker_count: u32 = 0;
     while (worker_iter.next()) |entity| {
         const worker_id = engine.entityToU64(entity);
-        Context.registerWorker(worker_id);
-        Context.workerIdle(worker_id);
+        _ = Context.workerAvailable(worker_id);
         worker_count += 1;
         std.log.info("[TaskInitializer] Registered worker {d} with task engine", .{worker_id});
     }

--- a/scripts/work_processor.zig
+++ b/scripts/work_processor.zig
@@ -48,9 +48,8 @@ pub fn update(game: *Game, scene: *Scene, dt: f32) void {
                 updated_progress.workstation_id,
             });
 
-            // Notify task engine that work is complete (via worker ID)
-            // The engine tracks which workstation the worker is at
-            _ = Context.pickupComplete(worker_id); // Work completion triggers next pickup phase
+            // Notify task engine that work is complete
+            _ = Context.workCompleted(updated_progress.workstation_id);
 
             // Remove the WorkProgress component
             registry.remove(WorkProgress, worker_entity);

--- a/scripts/worker_movement.zig
+++ b/scripts/worker_movement.zig
@@ -124,10 +124,8 @@ pub fn update(game: *Game, scene: *Scene, dt: f32) void {
                                 // This is the target EIS
                                 game.setWorldPositionXY(item_entity, storage_pos.x, storage_pos.y);
 
-                                // Set game pointers for hook enrichment before calling itemAdded
-                                Context.setGamePointers(registry, game);
-
                                 // Notify engine that item was added to storage
+                                // (registry/game pointers are automatically set via ensureContext)
                                 const storage_id = engine.entityToU64(storage_entity);
                                 _ = Context.itemAdded(storage_id, storage.accepts.?);
 
@@ -148,16 +146,16 @@ pub fn update(game: *Game, scene: *Scene, dt: f32) void {
                         }
                     } else {
                         // Regular task store - notify engine
-                        Context.storeComplete(worker_id);
+                        _ = Context.storeCompleted(worker_id);
                     }
                 },
                 .pickup, .transport_pickup => {
                     // Worker arrived to pick up item from storage (task engine managed)
-                    Context.pickupComplete(worker_id);
+                    _ = Context.pickupCompleted(worker_id);
                 },
                 .arrive_at_workstation => {
                     // Worker arrived at workstation to start work
-                    Context.storeComplete(worker_id);
+                    _ = Context.storeCompleted(worker_id);
                 },
             }
 
@@ -188,8 +186,8 @@ pub fn update(game: *Game, scene: *Scene, dt: f32) void {
                 // by checking if the old action was .store and there's no MovementTarget now
                 if (old_action == .store and registry.tryGet(MovementTarget, entity) == null) {
                     // This was a dangling item delivery completion, worker is now idle
-                    std.log.info("[WorkerMovement] Calling workerIdle for worker {d}", .{worker_id});
-                    Context.workerIdle(worker_id);
+                    std.log.info("[WorkerMovement] Calling workerAvailable for worker {d}", .{worker_id});
+                    _ = Context.workerAvailable(worker_id);
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

Updates bakery-game to use the new labelle-tasks Context API introduced in the upstream refactor (commits 107d1fb and 008600f).

## Changes

### API Updates
- Updated hook payloads: / → 
- Updated Context method names:
  -  → 
  -  → 
  -  → 
  -  → 
- Removed manual / calls (auto-registered via onAdd/onReady callbacks)

### Code Cleanup
- Removed  script - now uses  prefab directly
- Fixed Entity type handling in  hook
- Updated engine version to 0.52.5 to match labelle-tasks dependency

### Build System
- Manually create  module in build.zig to inject shared 
- Fixes module conflict when using local path dependency

## Testing
- Game builds and runs successfully
- Oven workstation created with all 6 storages (2 EIS, 2 IIS, 1 IOS, 1 EOS)
- Worker registration and dangling item pickup verified in logs

Closes #3